### PR TITLE
✨ add vue-i18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "twitter": "^1.7.1",
     "vue": "^2.4.2",
     "vue-electron": "^1.0.6",
+    "vue-i18n": "^7.3.2",
     "vue-loading-bar": "^1.0.0",
     "vue-router": "^2.5.3",
     "vue-scrollto": "^2.8.0",

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -13,13 +13,16 @@
   import appContent from './components/appContent'
   import appSpeedDial from './components/appSpeedDial'
 
+  import i18n from './i18n'
+
   export default {
     components: {
       appTitlebar,
       appModals,
       appContent,
       appSpeedDial
-    }
+    },
+    i18n
   }
 </script>
 

--- a/src/renderer/i18n/index.js
+++ b/src/renderer/i18n/index.js
@@ -1,0 +1,11 @@
+import Vue from 'vue'
+import VueI18n from 'vue-i18n'
+
+import locales from './locales'
+
+Vue.use(VueI18n)
+
+export default new VueI18n({
+  locale: 'en',
+  messages: locales
+})

--- a/src/renderer/i18n/locales/en.js
+++ b/src/renderer/i18n/locales/en.js
@@ -1,0 +1,5 @@
+export default {
+  message: {
+    hello: 'hello world'
+  }
+}

--- a/src/renderer/i18n/locales/index.js
+++ b/src/renderer/i18n/locales/index.js
@@ -1,0 +1,9 @@
+const files = require.context('.', false, /\.js$/)
+const locales = {}
+
+files.keys().forEach((key) => {
+  if (key === './index.js') return
+  locales[key.replace(/(\.\/|\.js)/g, '')] = files(key).default
+})
+
+export default locales


### PR DESCRIPTION
This PR is adding #1, support for Vue-i18n

The implementation is taken from [surfbirdapp/surfbird](https://github.com/surfbirdapp/surfbird) (my project, anyway :P)

This exposes a global `$i18n` instance and several translation functions, like `$t`. If you want to test out this feature, use this branch and put `{{ $t('message.hello') }}` anywhere in the Vue app.